### PR TITLE
Updating last_run_at for timezone change to work

### DIFF
--- a/celery_sqlalchemy_scheduler/tzcrontab.py
+++ b/celery_sqlalchemy_scheduler/tzcrontab.py
@@ -43,7 +43,7 @@ class TzAwareCrontab(schedules.crontab):
 
         """
         # convert last_run_at to the schedule timezone
-        # last_run_at = last_run_at.astimezone(self.tz)
+        last_run_at = last_run_at.astimezone(self.tz)
 
         rem_delta = self.remaining_estimate(last_run_at)
         rem = max(rem_delta.total_seconds(), 0)


### PR DESCRIPTION
Updating last_run_at in the database to reflect the new timezone. 