### PR TITLE
Removed code to set timezone info in last_run_at if not available

### DIFF
--- a/celery_sqlalchemy_scheduler/models.py
+++ b/celery_sqlalchemy_scheduler/models.py
@@ -4,6 +4,7 @@ import datetime as dt
 import pytz
 
 import sqlalchemy as sa
+from sqlalchemy import func
 from sqlalchemy.event import listen
 from sqlalchemy.orm import relationship, foreign, remote
 from sqlalchemy.sql import select, insert, update
@@ -270,7 +271,7 @@ class PeriodicTask(ModelBase, ModelMixin):
     total_run_count = sa.Column(sa.Integer(), nullable=False, default=0)
     # 修改时间
     date_changed = sa.Column(sa.DateTime(timezone=True),
-                             default=dt.datetime.now, onupdate=dt.datetime.now)
+                             default=func.now(), onupdate=func.now())
     # 说明
     description = sa.Column(sa.Text(), default='')
 

--- a/celery_sqlalchemy_scheduler/schedulers.py
+++ b/celery_sqlalchemy_scheduler/schedulers.py
@@ -99,7 +99,7 @@ class ModelEntry(ScheduleEntry):
         self.last_run_at = model.last_run_at
 
         # 因为从数据库读取的 last_run_at 可能没有时区信息，所以这里必须加上时区信息
-        self.last_run_at = self.last_run_at.replace(tzinfo=self.app.timezone)
+        # self.last_run_at = self.last_run_at.replace(tzinfo=self.app.timezone)
 
         # self.options['expires'] 同理
         # if 'expires' in self.options:


### PR DESCRIPTION
- Removed code to set timezone info in last_run_at if not available

> Explanation: As per model `celery_sqlalchemy_scheduler.models.PeriodicTask` the field `last_run_at` is set as `sa.Column(sa.DateTime(timezone=True))` hence timezone info will always be available in value of `last_run_at`. Also after code changes in commit: https://github.com/AngelLiang/celery-sqlalchemy-scheduler/commit/d5a040f29454b4d24b815644a0c74e3f4189c4db, conversion to schedule timezone is resolved, thereby the code at Line # 102 in class ModelEntry becomes redundant and hence commented.

- Updated default value in field date_changed

> Setting default & onupdate to `func.now()` will get the current time (like calling now() in Postgresql) every time a new record is added or an exiting record is updated, which I guess is the intent. Setting default & onupdate to `dt.datetime.now` will set the default value & onupdate value to the time when the server start and with every new addition or updation of record this preset value would be used.