### PR TITLE
Added unique constrain on name of the periodic task.

### DIFF
--- a/celery_sqlalchemy_scheduler/models.py
+++ b/celery_sqlalchemy_scheduler/models.py
@@ -220,7 +220,7 @@ class PeriodicTask(ModelBase, ModelMixin):
 
     id = sa.Column(sa.Integer, primary_key=True, autoincrement=True)
     # name
-    name = sa.Column(sa.String(255))
+    name = sa.Column(sa.String(255), unique=True)
     # task name
     task = sa.Column(sa.String(255))
 


### PR DESCRIPTION
While loading all schedule (https://github.com/AngelLiang/celery-sqlalchemy-scheduler/blob/master/celery_sqlalchemy_scheduler/schedulers.py#L324), a dictionary is created for all entries in periodic schedule table. Key in the dictionary is the name of the schedule. If the name of multiple schedules are same, then dictionary will have only one entry (last in the sequence to be specific) corresponding to that name and some of the entries in periodic task table will not be present in the resulting dict. It will be better to have explicit check on uniqueness on name while creating schedule.